### PR TITLE
Resolves #183: pass the transformed list of files to metalsmith.match…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,7 +128,7 @@ function initLayouts(options) {
     }
 
     // Filter files by the pattern
-    const matchedFiles = metalsmith.match(settings.pattern)
+    const matchedFiles = metalsmith.match(settings.pattern, Object.keys(files))
 
     // Filter files by validity
     const validFiles = matchedFiles.filter((filename) => validate({ filename, files, settings }))


### PR DESCRIPTION
… so that renamed files can be matched

https://github.com/metalsmith/layouts/issues/183